### PR TITLE
Create scratchpads with custom file names

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -330,7 +330,7 @@
             // Find an available filename
             while (fs.existsSync(fullPath)) {
                 i = i ? i + 1 : 1;
-                filename = FILE_NAME_TEMPLATE + i + "." + ext;
+                filename = `${fileNameFromUser}${i}.${ext}`;
                 fullPath = path.join(projectScratchpadsPath, filename);
             }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -319,20 +319,30 @@
     function createScratchpad(type) {
         let i = undefined;
         let ext = type.ext;
-        let filename = FILE_NAME_TEMPLATE + "." + ext;
-        let fullPath = path.join(projectScratchpadsPath, filename);
+        const inputOptions = {
+            placeHolder: "Enter a filename",
+            value: FILE_NAME_TEMPLATE
+        };
+        window.showInputBox(inputOptions).then(fileNameFromUser => {
+            if (!fileNameFromUser) {
+                fileNameFromUser = FILE_NAME_TEMPLATE;
+            }
+            
+            let filename = `${fileNameFromUser}.${ext}`;
+            let fullPath = path.join(projectScratchpadsPath, filename);
 
-        // Find an available filename
-        while (fs.existsSync(fullPath)) {
-            i = i ? i + 1 : 1;
-            filename = FILE_NAME_TEMPLATE + i + "." + ext;
-            fullPath = path.join(projectScratchpadsPath, filename);
-        }
+            // Find an available filename
+            while (fs.existsSync(fullPath)) {
+                i = i ? i + 1 : 1;
+                filename = FILE_NAME_TEMPLATE + i + "." + ext;
+                fullPath = path.join(projectScratchpadsPath, filename);
+            }
 
-        fs.writeFileSync(fullPath, "");
+            fs.writeFileSync(fullPath, "");
 
-        vscode.workspace.openTextDocument(fullPath).then(doc => {
-            window.showTextDocument(doc);
+            vscode.workspace.openTextDocument(fullPath).then(doc => {
+                window.showTextDocument(doc);
+            });
         });
     }
 
@@ -457,10 +467,7 @@
         let files = fs.readdirSync(projectScratchpadsPath);
 
         for (var i = 0, len = files.length; i < len; i++) {
-            var match = files[i].match(FILE_NAME_TEMPLATE + ".*");
-            if (match !== null) {
-                fs.unlinkSync(path.join(projectScratchpadsPath, match[0]));
-            }
+            fs.unlinkSync(path.join(projectScratchpadsPath, match[0]));
         }
 
         window.showInformationMessage("Removed all scratchpads");

--- a/src/extension.js
+++ b/src/extension.js
@@ -463,7 +463,7 @@
         let files = fs.readdirSync(projectScratchpadsPath);
 
         for (var i = 0, len = files.length; i < len; i++) {
-            fs.unlinkSync(path.join(projectScratchpadsPath, match[0]));
+            fs.unlinkSync(path.join(projectScratchpadsPath, files[i]));
         }
 
         window.showInformationMessage("Removed all scratchpads");

--- a/src/extension.js
+++ b/src/extension.js
@@ -82,8 +82,7 @@
             path.join(
                 path.basename(context.globalStoragePath),
                 SCRATCHPADS_FOLDER,
-                projectPathMD5,
-                FILE_NAME_TEMPLATE
+                projectPathMD5
             )
         );
 
@@ -319,11 +318,8 @@
     function createScratchpad(type) {
         let i = undefined;
         let ext = type.ext;
-        const inputOptions = {
-            placeHolder: "Enter a filename",
-            value: FILE_NAME_TEMPLATE
-        };
-        window.showInputBox(inputOptions).then(fileNameFromUser => {
+        
+        getUserInput("Enter a filename:").then(fileNameFromUser => {
             if (!fileNameFromUser) {
                 fileNameFromUser = FILE_NAME_TEMPLATE;
             }


### PR DESCRIPTION
Added functionality to create scratchpads with custom filenames.

Hence I removed the functionality where each file is matched with the default naming convention before removal. 

I assume, it wouldn't affect anything since we have a separate highly specific directory for storing them but incase it would affect something, please let me know. 

Thanks!