### PR TITLE
feat(config): add option to not use subfolders

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
           "type": "string",
           "default": "",
           "description": "The default file extension to use with 'New scratchpad (default)' command (e.g., 'js', 'ts', 'py')"
+        },
+        "scratchpads.useSubfolders": {
+          "type": "boolean",
+          "default": true,
+          "description": "Save scratchpads in project-specific subfolders. When disabled, all scratchpads are saved in a single folder."
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { Md5 } from 'ts-md5';
 import * as vscode from 'vscode';
-import { CONFIG_SCRATCHPADS_FOLDER, RECENT_FILETYPES_FILE, SCRATCHPADS_FOLDER_NAME } from './consts';
+import { CONFIG_SCRATCHPADS_FOLDER, CONFIG_USE_SUBFOLDERS, RECENT_FILETYPES_FILE, SCRATCHPADS_FOLDER_NAME } from './consts';
 
 export class Config {
   public static context: vscode.ExtensionContext;
@@ -34,9 +34,17 @@ export class Config {
    */
   public static recalculatePaths() {
     this.customPath = this.getExtensionConfiguration(CONFIG_SCRATCHPADS_FOLDER) as string;
+    const useSubfolders = this.getExtensionConfiguration(CONFIG_USE_SUBFOLDERS) as boolean;
 
     this.scratchpadsRootPath = path.join(this.customPath || this.globalPath, SCRATCHPADS_FOLDER_NAME);
-    this.projectScratchpadsPath = path.join(this.scratchpadsRootPath, this.projectPathMD5);
+    
+    // Use subfolders by default (true) unless explicitly disabled
+    if (useSubfolders !== false) {
+      this.projectScratchpadsPath = path.join(this.scratchpadsRootPath, this.projectPathMD5);
+    } else {
+      this.projectScratchpadsPath = this.scratchpadsRootPath;
+    }
+    
     this.recentFiletypesFilePath = path.join(this.scratchpadsRootPath, RECENT_FILETYPES_FILE);
   }
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -12,3 +12,4 @@ export const CONFIG_PROMPT_FOR_FILENAME = 'promptForFilename';
 export const CONFIG_PROMPT_FOR_REMOVAL = 'promptForRemoval';
 export const CONFIG_RENAME_WITH_EXTENSION = 'renameWithExtension';
 export const CONFIG_SCRATCHPADS_FOLDER = 'scratchpadsFolder';
+export const CONFIG_USE_SUBFOLDERS = 'useSubfolders';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
-import {Config} from './config';
-import {FiletypesManager} from './filetypes.manager';
-import {ScratchpadsManager} from './scratchpads.manager';
+import { Config } from './config';
+import { FiletypesManager } from './filetypes.manager';
+import { ScratchpadsManager } from './scratchpads.manager';
 import Utils from './utils';
 
 /**
@@ -32,10 +32,11 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(cmd);
   }
 
-  vscode.workspace.onDidChangeConfiguration((event) => {
-    const affected = event.affectsConfiguration('scratchpads.scratchpadsFolder');
+  vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+    const affectedFolder = event.affectsConfiguration('scratchpads.scratchpadsFolder');
+    const affectedSubfolders = event.affectsConfiguration('scratchpads.useSubfolders');
 
-    if (affected) {
+    if (affectedFolder || affectedSubfolders) {
       Config.recalculatePaths();
     }
   });


### PR DESCRIPTION
Hello! Very happy about this extension - thank you very much. However, I would find it convenient if there was an option to put all scratchfiles in the root scratchpads folder, rather then separated out into subfolders. I've made the modification in this PR to allow this. I don't know TS, so there may be some issues.


Changes include:
✅ New Feature: Added useSubfolders setting to package.json
✅ Configuration Logic: Modified config.ts to check the setting and adjust paths accordingly
✅ Event Handling: Updated extension.ts to listen for configuration changes
✅ Default Behavior: Maintains backward compatibility (subfolders enabled by default)