### PR TITLE
Add allowedFiletypes setting to restrict filetype picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scratchpads",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scratchpads",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "language-map": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
           "default": "",
           "description": "The default file extension to use with 'New scratchpad (default)' command (e.g., 'js', 'ts', 'py')"
         },
+        "scratchpads.allowedFiletypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Restrict the filetype picker to only these extensions (e.g., ['txt', 'rb', 'md']). When empty, all filetypes are shown."
+        },
         "scratchpads.showInExplorer": {
           "type": "boolean",
           "default": false,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,6 +7,7 @@ export const GLOBAL_SCRATCHPADS_FOLDER_NAME = '__globalScratchpads__';
 // Configuration constants
 export const CONFIG_AUTO_FORMAT = 'autoFormat';
 export const CONFIG_AUTO_PASTE = 'autoPaste';
+export const CONFIG_ALLOWED_FILETYPES = 'allowedFiletypes';
 export const CONFIG_DEFAULT_FILETYPE = 'defaultFiletype';
 export const CONFIG_FILE_PREFIX = 'filePrefix';
 export const CONFIG_PROMPT_FOR_FILENAME = 'promptForFilename';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,8 @@ export async function activate(context: vscode.ExtensionContext) {
     return;
   }
 
-  const scratchpadsManager = new ScratchpadsManager(new FiletypesManager());
+  const filetypesManager = new FiletypesManager();
+  const scratchpadsManager = new ScratchpadsManager(filetypesManager);
 
   // Register tree view
   const treeViewProvider = new ScratchpadTreeProvider();
@@ -88,6 +89,10 @@ export async function activate(context: vscode.ExtensionContext) {
       Config.recalculatePaths();
       // Refresh the tree view to show files from the new path
       treeViewProvider.refreshOnConfigChange();
+    }
+
+    if (event.affectsConfiguration('scratchpads.allowedFiletypes')) {
+      filetypesManager.markDirty();
     }
   });
 

--- a/src/filetypes.manager.ts
+++ b/src/filetypes.manager.ts
@@ -220,17 +220,10 @@ export class FiletypesManager {
     if (!this.filetypeItems.length || this.isFiletypeItemsDirty) {
       this.filetypeItems = [];
 
-      const allowedFiletypes = (Config.getExtensionConfiguration(CONFIG_ALLOWED_FILETYPES) as string[]) || [];
-      const allowedSet = new Set(allowedFiletypes.map((ext) => this.normalizeExtension(ext)));
-      const hasAllowList = allowedSet.size > 0;
-
-      const filterByAllowList = (items: Filetype[]) =>
-        hasAllowList ? items.filter((item) => allowedSet.has(this.normalizeExtension(item.ext))) : items;
-
-      const recentFiletypes = filterByAllowList(this.recentFiletypes);
+      const recentFiletypes = this.filterByAllowList(this.recentFiletypes);
       const allFiletypes = [
-        ...this.filterOutRecentFiletypes(filterByAllowList(this.mainFiletypes)),
-        ...this.filterOutRecentFiletypes(filterByAllowList(this.additionalFiletypes)),
+        ...this.filterOutRecentFiletypes(this.filterByAllowList(this.mainFiletypes)),
+        ...this.filterOutRecentFiletypes(this.filterByAllowList(this.additionalFiletypes)),
       ];
 
       this.addFiletypeOptionsToSection('Recent', recentFiletypes);
@@ -282,6 +275,23 @@ export class FiletypesManager {
     for (const type of typesToAdd) {
       this.filetypeItems.push({ label: `${type.name} (${type.ext})`, type });
     }
+  }
+
+  /**
+   * Filter items to only include extensions in the allowedFiletypes config.
+   * Returns the original array unmodified if no allow list is configured.
+   * @param items The array to filter
+   * @returns The filtered array
+   */
+  private filterByAllowList(items: Filetype[]) {
+    const allowedFiletypes = (Config.getExtensionConfiguration(CONFIG_ALLOWED_FILETYPES) as string[]) || [];
+    const allowedSet = new Set(allowedFiletypes.map((ext) => this.normalizeExtension(ext)));
+
+    if (allowedSet.size === 0) {
+      return items;
+    }
+
+    return items.filter((item) => allowedSet.has(this.normalizeExtension(item.ext)));
   }
 
   /**

--- a/src/filetypes.manager.ts
+++ b/src/filetypes.manager.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { window } from 'vscode';
 import { Config } from './config';
-import { CONFIG_DEFAULT_FILETYPE } from './consts';
+import { CONFIG_ALLOWED_FILETYPES, CONFIG_DEFAULT_FILETYPE } from './consts';
 import { InputBox } from './input-box';
 
 export interface Filetype {
@@ -24,6 +24,14 @@ export class FiletypesManager {
   constructor() {
     this.loadFiletypes();
     this.prepareItems();
+  }
+
+  /**
+   * Marks the filetype items list as dirty so it will be rebuilt on next access.
+   * Call this when configuration changes affect the filetype list.
+   */
+  public markDirty() {
+    this.isFiletypeItemsDirty = true;
   }
 
   /**
@@ -205,16 +213,28 @@ export class FiletypesManager {
    * Organizes items into sections:
    * - Recent filetypes
    * - All available filetypes (main + additional)
-   * Only rebuilds list if items are marked as dirty
+   * Only rebuilds list if items are marked as dirty.
+   * When allowedFiletypes is configured, filters to only show those extensions.
    */
   private prepareItems() {
     if (!this.filetypeItems.length || this.isFiletypeItemsDirty) {
       this.filetypeItems = [];
-      this.addFiletypeOptionsToSection('Recent', this.recentFiletypes);
-      this.addFiletypeOptionsToSection('File types', [
-        ...this.filterOutRecentFiletypes(this.mainFiletypes),
-        ...this.filterOutRecentFiletypes(this.additionalFiletypes),
-      ]);
+
+      const allowedFiletypes = (Config.getExtensionConfiguration(CONFIG_ALLOWED_FILETYPES) as string[]) || [];
+      const allowedSet = new Set(allowedFiletypes.map((ext) => this.normalizeExtension(ext)));
+      const hasAllowList = allowedSet.size > 0;
+
+      const filterByAllowList = (items: Filetype[]) =>
+        hasAllowList ? items.filter((item) => allowedSet.has(this.normalizeExtension(item.ext))) : items;
+
+      const recentFiletypes = filterByAllowList(this.recentFiletypes);
+      const allFiletypes = [
+        ...this.filterOutRecentFiletypes(filterByAllowList(this.mainFiletypes)),
+        ...this.filterOutRecentFiletypes(filterByAllowList(this.additionalFiletypes)),
+      ];
+
+      this.addFiletypeOptionsToSection('Recent', recentFiletypes);
+      this.addFiletypeOptionsToSection('File types', allFiletypes);
 
       this.isFiletypeItemsDirty = false;
     }


### PR DESCRIPTION
## Summary

Adds a new `scratchpads.allowedFiletypes` setting (string array) that restricts which file extensions appear in the filetype picker.

- When configured (e.g., `["txt", "rb", "md"]`), only matching extensions are shown in both the "Recent" and "File types" sections
- When empty (default), all filetypes are shown — fully backward compatible
- Extensions are matched case-insensitively and with/without leading dots
- The picker refreshes automatically when the setting changes

### Example usage

```json
{
  "scratchpads.allowedFiletypes": ["txt", "rb", "md"]
}
```

This addresses the common pain point of the picker showing 100+ file types when users only need a handful.