### PR TITLE
Add removeEmptyOnClose setting to auto-delete empty scratchpads

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
           "default": true,
           "description": "Prompt the user when removing all scratchpads"
         },
+        "scratchpads.removeEmptyOnClose": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically remove a scratchpad file when it is closed empty"
+        },
         "scratchpads.promptForFilename": {
           "type": "boolean",
           "default": false,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -12,6 +12,7 @@ export const CONFIG_DEFAULT_FILETYPE = 'defaultFiletype';
 export const CONFIG_FILE_PREFIX = 'filePrefix';
 export const CONFIG_PROMPT_FOR_FILENAME = 'promptForFilename';
 export const CONFIG_PROMPT_FOR_REMOVAL = 'promptForRemoval';
+export const CONFIG_REMOVE_EMPTY_ON_CLOSE = 'removeEmptyOnClose';
 export const CONFIG_RENAME_WITH_EXTENSION = 'renameWithExtension';
 export const CONFIG_SCRATCHPADS_FOLDER = 'scratchpadsFolder';
 export const CONFIG_SHOW_IN_EXPLORER = 'showInExplorer';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Config } from './config';
+import { CONFIG_REMOVE_EMPTY_ON_CLOSE } from './consts';
 import { FiletypesManager } from './filetypes.manager';
 import { ScratchpadTreeProvider } from './scratchpad-tree-provider';
 import { ScratchpadsManager } from './scratchpads.manager';
@@ -101,6 +102,32 @@ export async function activate(context: vscode.ExtensionContext) {
     Config.recalculatePaths();
     treeViewProvider.refreshOnConfigChange();
   });
+
+  context.subscriptions.push(
+    vscode.window.tabGroups.onDidChangeTabs((event) => {
+      if (!Config.getExtensionConfiguration(CONFIG_REMOVE_EMPTY_ON_CLOSE)) {
+        return;
+      }
+
+      for (const tab of event.closed) {
+        if (!(tab.input instanceof vscode.TabInputText)) {
+          continue;
+        }
+
+        const filePath = tab.input.uri.fsPath;
+
+        if (!Utils.isScratchpadFile(filePath)) {
+          continue;
+        }
+
+        try {
+          Utils.deleteFileIfEmpty(filePath);
+        } catch (error) {
+          console.error('[Scratchpads] removeEmptyOnClose error:', error);
+        }
+      }
+    }),
+  );
 }
 
 /**

--- a/src/scratchpads.manager.ts
+++ b/src/scratchpads.manager.ts
@@ -310,12 +310,7 @@ export class ScratchpadsManager {
    * @param {TextEditor} editor The tab to inspect
    */
   private isScratchpadEditor(editor?: vscode.TextEditor) {
-    if (editor) {
-      const editorPath = path.dirname(editor.document.fileName);
-      return editorPath === Config.projectScratchpadsPath;
-    }
-
-    return false;
+    return editor !== undefined && Utils.isScratchpadFile(editor.document.fileName);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -204,6 +204,24 @@ export default class Utils {
   }
 
   /**
+   * Check if the given file path belongs to the scratchpads folder
+   * @param filePath Full path to the file
+   */
+  public static isScratchpadFile(filePath: string): boolean {
+    return path.dirname(filePath) === Config.projectScratchpadsPath;
+  }
+
+  /**
+   * Delete a file if its content is empty or whitespace-only
+   * @param filePath Full path to the file
+   */
+  public static deleteFileIfEmpty(filePath: string): void {
+    if (fs.existsSync(filePath) && fs.readFileSync(filePath, 'utf8').trim() === '') {
+      fs.unlinkSync(filePath);
+    }
+  }
+
+  /**
    * Check if file exists and prompt for overwrite if needed
    * @param filePath Path to check
    * @param fileName Display name for the dialog


### PR DESCRIPTION
This PR adds an option to remove an empty scratchpad when its tab is closed.

It mimics the behavior of JetBrains editors.